### PR TITLE
3 new options for the struct creator (Xorm,Base Tables, Nullables)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ _cgo_export.*
 _testmain.go
 
 *.exe
+
+# Ignore the file that was created on test
+db_structs.go

--- a/main.go
+++ b/main.go
@@ -89,7 +89,17 @@ func writeStructs(schemas []ColumnSchema) (int, error) {
 		}
 		out = out + "\t" + formatName(cs.ColumnName) + " " + goType
 		if len(config.TagLabel) > 0 {
-			out = out + "\t`" + config.TagLabel + ":\"" + cs.ColumnName + "\"`"
+			if config.Xorm {
+				out = out + "\t`" + config.TagLabel + ":"
+				if cs.ColumnName == "id" {
+					out = out + "\"'" + cs.ColumnName + "' pk autoincr"
+				} else {
+					out = out + "\"" + cs.ColumnName
+				}
+				out = out + "\" json:\"" + cs.ColumnName + "\"`"
+			} else {
+				out = out + "\t`" + config.TagLabel + ":\"" + cs.ColumnName + "\"`"
+			}
 		}
 		out = out + "\n"
 		currentTable = cs.TableName

--- a/test.json
+++ b/test.json
@@ -1,9 +1,10 @@
 {
 	"db_user": "test",
 	"db_password": "test",
-	"db_name": "test",
+	"db_name": "fusion",
 	"pkg_name": "JsonTest",
 	"tag_label": "db",
 	"xorm":true,
-	"only_base_tables":true
+	"only_base_tables":true,
+	"ignore_nullables":true
 }

--- a/test.json
+++ b/test.json
@@ -1,7 +1,9 @@
 {
 	"db_user": "test",
 	"db_password": "test",
-	"db_name": "test",
+	"db_name": "fusion",
 	"pkg_name": "JsonTest",
-	"tag_label": "db"
+	"tag_label": "db",
+	"xorm":true,
+	"only_base_tables":true
 }

--- a/test.json
+++ b/test.json
@@ -1,7 +1,7 @@
 {
 	"db_user": "test",
 	"db_password": "test",
-	"db_name": "test",
+	"db_name": "fusion",
 	"pkg_name": "JsonTest",
 	"tag_label": "db",
 	"xorm":true,

--- a/test.json
+++ b/test.json
@@ -1,7 +1,7 @@
 {
 	"db_user": "test",
 	"db_password": "test",
-	"db_name": "fusion",
+	"db_name": "test",
 	"pkg_name": "JsonTest",
 	"tag_label": "db",
 	"xorm":true,

--- a/test.json
+++ b/test.json
@@ -1,9 +1,9 @@
 {
 	"db_user": "test",
 	"db_password": "test",
-	"db_name": "fusion",
-	"pkg_name": "JsonTest",
-	"tag_label": "db",
+	"db_name": "go_fusion",
+	"pkg_name": "db",
+	"tag_label": "xorm",
 	"xorm":true,
 	"only_base_tables":true,
 	"ignore_nullables":true

--- a/test.json
+++ b/test.json
@@ -1,7 +1,7 @@
 {
-	"db_user": "db_user",
-	"db_password": "db_pass",
-	"db_name": "db_name",
+	"db_user": "test",
+	"db_password": "test",
+	"db_name": "test",
 	"pkg_name": "JsonTest",
 	"tag_label": "db"
 }


### PR DESCRIPTION
Hey guys,

I'm adding 3 new options for the struct creator. 

1) Xorm support - this creates the necessary function for passing directly into a xorm query along with primary key and auto increment support.
2) Base Tables - Only build structs from base tables.. at my work we use a lot of views along with base tables and it's annoying for the tool to create structs based on the views.
3) Ignore nullables - working on a 3rd version of our app and it's nice to have the structs built from another DB when this app doesn't necessarily want sql.Nullable* in the structs.

All three options are false by default so it shouldn't affect anyone currently using the creator.

Thanks!

- Nick